### PR TITLE
Add US CPI and rates downloads via FRED

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 This repository provides small utilities for downloading publicly available
 macroeconomic datasets. It now supports both United States indicators from
-FRED and Euro area indicators from the European Central Bank (ECB).
+FRED (Consumer Price Index and benchmark interest rates) and Euro area
+indicators from the European Central Bank (ECB).
 
+## Quick examples
 
-# Everything (Euribor + FX + HICP agg + HICP sector pivots)
+```bash
+# Everything (ECB Euribor + FX + HICP aggregates/pivots + US CPI + US rates)
 python ecb_suite.py --start 2015-01 --end 2025-09
 
-# Only Euribor, custom output
+# Only Euribor, custom output name
 python ecb_suite.py --run euribor --start 2010-01 --out-euribor euribor_2010_2025.csv
 
 # Only FX with restricted set of currencies
@@ -19,4 +22,14 @@ python ecb_suite.py --run hicp_agg --measure ANR --start 2015-01
 
 # Only HICP by sector (INX), keep your two exports
 python ecb_suite.py --run hicp_sector --measure INX --start 2015-01
+
+# Only US CPI (index + YoY inflation)
+python ecb_suite.py --run us_inflation --start 2000-01 --out-us-inflation us_cpi.csv
+
+# Only US benchmark interest rates
+python ecb_suite.py --run us_rates --start 2000-01 --out-us-rates us_rates.csv
+
+# Run both US downloads without ECB data
+python ecb_suite.py --run us --start 2000-01
+```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.0
 ecbdata>=0.1
+requests>=2.0


### PR DESCRIPTION
## Summary
- add FRED helper utilities to download US CPI inflation and benchmark rates alongside existing ECB data
- extend the CLI with new US-focused run modes and configurable output paths
- document the new capabilities and add the requests dependency required for FRED access

## Testing
- pip install -r requirements.txt
- python ecb_suite.py --run us --start 2020-01 --end 2020-03 *(fails: outbound HTTPS proxy blocks access to fred.stlouisfed.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d94639b58c83299f5da854b6b4fded