### PR TITLE
Handle inconsistent FRED CSV headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.0
 ecbdata>=0.1
+requests>=2.0


### PR DESCRIPTION
## Summary
- normalize FRED CSV headers after download and detect date/value columns case-insensitively
- keep error handling while renaming the timestamp column to DATE for downstream parsing
- declare the requests dependency explicitly in requirements

## Testing
- python -m compileall ecb_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68d999267e448329a39d6562e898b004